### PR TITLE
Extra whitespace can cause issues

### DIFF
--- a/Source/Dna.HtmlEngine.Core/Engines/Base/BaseEngine.cs
+++ b/Source/Dna.HtmlEngine.Core/Engines/Base/BaseEngine.cs
@@ -356,7 +356,7 @@ namespace Dna.HtmlEngine.Core
                         return;
 
                     // Otherwise, load the monitor path
-                    monitor = monitor.Substring("monitor: ".Length);
+                    monitor = monitor.Substring("monitor:".Length).Trim();
 
                     // Convert path to full path
                     if (Path.IsPathRooted(monitor))


### PR DESCRIPTION
An extra space between the ‘monitor:’ token and the value causes the path parsing to fail. This makes that more robust by cleaning the whitespace.